### PR TITLE
Usage of the reserved word 'int' makes Closure Compiler throw errors.

### DIFF
--- a/test/Parser.test.js
+++ b/test/Parser.test.js
@@ -719,7 +719,7 @@ exports.getTrigramRank = function (t) {
     hos:62,
     'if ':63,
     imi:64,
-    int:65,
+    'int':65,
     itl:66,
     jus:67,
     'l w':68,


### PR DESCRIPTION
Stringed out.
