### PR TITLE
Fixed bug when using limit on detect and specifying languageType

### DIFF
--- a/lib/LanguageDetect.js
+++ b/lib/LanguageDetect.js
@@ -213,8 +213,6 @@ LanguageDetect.prototype = {
 
     if (!scoresLength) return [];
 
-    scores = limit > 0 ? scores.slice(0, limit) : scores;
-
     switch (me.languageType) {
       case 'iso2':
         for (i = scoresLength; i--;) {


### PR DESCRIPTION
While testing your module with the limit option I encountered a problem when the languageType was set, returning the following error:

```
Cannot read property '0' of undefined
```

Here is a patch for the above.
