### PR TITLE
Fixed #35: TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare module 'languagedetect' {
          * setLanguageType('iso2');
          * @param languageType
          */
-        setLanguageType(languageType): void;
+        setLanguageType(languageType: string): void;
     }
 
     export = LanguageDetect;


### PR DESCRIPTION
This PR fixes #35 by adding the `string` type to parameter `languageType`.